### PR TITLE
feat(OTHER_CATEGORY): Add OpenStationMap

### DIFF
--- a/maps.js
+++ b/maps.js
@@ -858,6 +858,24 @@ const maps = [
 			}
 		},
 	},
+	
+	{
+		name: "OpenStationMap",
+		category: OTHER_CATEGORY,
+		default_check: false,
+		domain: "openstationmap.org",
+		getUrl(lat, lon, zoom) {
+			return "https://openstationmap.org/#" + zoom + "/" + lat + "/" + lon;
+		},
+		getLatLonZoom(url) {
+			const match = url.match(/openstationmap\.org\/#(\d[0-9.]*)\/(-?\d[0-9.]*)\/(-?\d[0-9.]*)/);
+			if (match) {
+				let [, zoom, lat, lon] = match;
+				zoom = Math.round(Number(zoom));
+				return [lat, lon, zoom];
+			}
+		},
+	},
 
 	{
 		name: "OSM Buildings",


### PR DESCRIPTION
It can show public transport station's indoor map.

The default url will jump to `https://openstationmap.org/#17/52.52476/13.36949/8.8/55`

`8.8` and `55` is 3D parameter, if ignore those 2 parameter it will be a 2D map.