### PR TITLE
Use history.pushState and allow popstate

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,8 @@
 	<nav class="navbar navbar-primary bg-primary text-light p-0" id="main_navbar">
 		<h1 class="h4"> 🗺️OpenSwitchMaps Web🗺️</h1>
 		<div>
-			Map URL:<input type="url" class="" id="inputbox_map_url" placeholder="Enter Map URL">
-			<button type="submit" id="button_refresh_links" class="btn btn-secondary btn-sm" onclick="button_refresh_links();">Refresh links</button>
+			Map URL:<input type="url" id="inputbox_map_url" placeholder="Enter Map URL" onkeypress="input_key_press(event);">
+			<button id="button_refresh_links" class="btn btn-secondary btn-sm" onclick="button_refresh_links();">Refresh links</button>
 		</div>
 
 		

--- a/main.js
+++ b/main.js
@@ -180,6 +180,7 @@ function setAddress(lat, lon) {
 		}
 	};
 	request.send();
+	return request;
 }
 
 
@@ -324,14 +325,29 @@ function setMaps(lat, lon, zoom, maps, pin_lat, pin_lon, changeset){
   document.getElementById("maps").innerHTML =  maplist;
 }
 
+function input_key_press(event) {
+	if (event.key == 'Enter') button_refresh_links()
+}
+
 function button_refresh_links(){
-	
 	const url = document.getElementById('inputbox_map_url').value;
-	history.replaceState('','','index.html#' + url);
+	update_from_url(url);
+	history.pushState({url: url},'','#' + url);
+}
+
+function update_from_url(url){
 	const latlonzoom = getLatLonZoom(url, maps);
 	update_map_links(latlonzoom); 
 	setAddress(latlonzoom[0], latlonzoom[1]);
 }
+
+window.addEventListener('popstate', function (event) {
+	const state = event.state;
+	const url = state.url;
+	update_from_url(url);
+	document.getElementById('inputbox_map_url').value = url;
+})
+
 function hide_instructions(){
 	document.getElementById("description").style.display = "none";
 }
@@ -536,14 +552,5 @@ init();
 init_maps();
 const prev_url = get_prev_url();
 if (prev_url) hide_instructions();
-const latlonzoom = getLatLonZoom(prev_url, maps);
-update_map_links(latlonzoom); 
-setAddress(latlonzoom[0], latlonzoom[1]);
-
-
-
-
-
-  
-
-  
+update_from_url(prev_url);
+history.replaceState({url: prev_url}, '', '#'+prev_url);


### PR DESCRIPTION
Use history.pushState instead of replaceState, so we can go back to the history (with popstate).
Do you have any reason to use replaceState instead of pushState?

Allow press enter to update url in input box.

I also remove the `type="submit"` in the button, since it will not submit any form.

## Todo
We should save the address into the state object too, so we don't have to send ajax while navigating in history.
Though it will be a little over-engineering, and I can not organize code well now too.
Can I use async or promise here? Ajax will be painful without promise, but I am not sure whether @tankaru is familar with it.