### PR TITLE
Support pin in Bing map

### DIFF
--- a/main.js
+++ b/main.js
@@ -596,6 +596,9 @@ let is_gcj_in_china = false;
 init();
 init_maps();
 const prev_url = get_prev_url();
-if (prev_url) hide_instructions();
+if (prev_url) {
+	hide_instructions();
+	document.getElementById('inputbox_map_url').value = prev_url;
+}
 update_from_url(prev_url);
 history.replaceState({url: prev_url}, '', '#'+prev_url);

--- a/maps.js
+++ b/maps.js
@@ -270,9 +270,31 @@ const maps = [
 		default_check: true,
 		domain: "www.bing.com",
 		is_gcj_in_china: true,
-		getUrl(lat, lon, zoom) {
-			return "https://www.bing.com/maps?cp=" + lat + "~" + lon + "&lvl=" + zoom;
+		getUrl(lat, lon, zoom, pin_lat, pin_lon) {
+			// https://learn.microsoft.com/en-us/bingmaps/articles/create-a-custom-map-url#collections-categories 
+			let pin = ''
+			if (pin_lat != null) {
+				pin = `&sp=point.${pin_lat}_${pin_lon}` // + `${name}_${note}`;
+			}
+			return "https://www.bing.com/maps?cp=" + lat + "~" + lon + "&lvl=" + zoom + pin;
 		},
+		getLatLonZoom(url) {
+			// https://www.bing.com/maps?osid=7b4e7fbd-4878-44fa-8302-421100f0d920&cp=23.295311~120.807682&lvl=13&v=2&sV=2&form=S00027
+			const u = new URL(url);
+			const center = u.get('cp');
+			if (!center) return;
+			const [lat, lon] = center.split('~')
+			let zoom = '14';
+			if (u.has('lvl')) zoom = u.get('lvl');
+			const ret = [lat, lon, zoom];
+			
+			const pin = u.get('sp');
+			if (pin) {
+				const scan = pin.match(/point\.([\d.]+)_([\d.]+)/);
+				if (scan) ret.push(scan[1], scan[2]);
+			}
+			return ret;
+		}
 	},
 	{
 		name: "Overpass-turbo",


### PR DESCRIPTION
* Support generating Bing map url with a pin.
* Show url in inputbox when the web-page loaded.
* Parse lat, lon, zoom and pin from Bing map url if they appear.
  However, the parameter in url may not be same to the map view in the browser if the user move the map.
  If you don't like this misleading behavior, just remove that part of code.