### PR TITLE
chore(maps.js): Stadia Maps

### DIFF
--- a/maps.js
+++ b/maps.js
@@ -447,6 +447,24 @@ let maps = [
 		},
 	},
 	{
+		//https://stadiamaps.com/explore-the-map/#map=10.56/37.5697/126.9976
+		name: "Stadia Maps",
+		category: OTHER_CATEGORY,
+		default_check: true,
+		domain: "stadiamaps.com",
+		description: "",
+		getUrl(lat, lon, zoom) {
+			return "https://stadiamaps.com/explore-the-map/#?map=" + zoom + "/" + lat + "/" + lon;
+		},
+		getLatLonZoom(url) {
+			const match = url.match(/stadiamaps\.com\/explore-the-map\/#.*\?map=(\d[0-9.]*)\/(-?\d[0-9.]*)\/(-?\d[0-9.]*)/);
+			if (match) {
+				const [, zoom, lat, lon] = match;
+				return [lat, lon, zoom];
+			}
+		},
+	},
+	{
 		name: "BigMap 2",
 		category: UTILITY_CATEGORY,
 		default_check: true,


### PR DESCRIPTION
Add Stadia Maps' demo page (contain 5 style: alidade smooth/smoothdark/satelite, OSM bright, outdoors)

Actually discovered it a long time ago, but I have been forgetting to submit a PR. Recently, Stamen is about to stop serving and hand over to Stadia Maps to continue hosting Toner/Terrain/Watercolor, so I noticed this repository again
